### PR TITLE
Added reaction event to add users to a meeting

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,8 +28,23 @@ async def process_command(message):
             await client.logout()
         elif (parameters[0] == 'meeting'):
             await make_meeting(parameters[1:])
+            message = await message.channel.send('React with \N{THUMBS UP SIGN} to enrol in {}'.format(parameters[1]))
+            await message.add_reaction('\N{THUMBS UP SIGN}')
+            meetings[-1].setMessage(message)
         elif (parameters[0] == 'show_meetings'):
             await show_meetings(message)
+        elif (parameters[0] == 'check_meetings'):
+            for meeting in meetings:
+                await message.channel.send(meeting)
+
+@client.event
+async def on_reaction_add(reaction, user):
+    channel = reaction.message.channel
+    if(user != client.user and reaction.emoji == '\N{THUMBS UP SIGN}'):
+        for meeting in meetings:
+            if (reaction.message == meeting.getMessage()):
+                meeting.addParticipant(user)
+                await channel.send("{} has added successfully signed up for {}".format(user.name, meeting.name))
 
 @client.event
 async def on_ready():

--- a/schedule.py
+++ b/schedule.py
@@ -6,11 +6,12 @@ in how participants will be stored).
 import datetime
 
 class Meeting:
-    def __init__(self, name, time = datetime.time(0,0,0), date = datetime.date(2000, 1, 1), participants = [], desc = "", auto_remind = False):
+    def __init__(self, name, time = datetime.time(0,0,0), date = datetime.date(2000, 1, 1), participants = [], message = "", desc = "", auto_remind = False):
         self.name = name
         self.time = time
         self.date = date
         self.participants = participants
+        self.message = message
         self.desc = desc
         self.auto_remind = auto_remind
     
@@ -35,6 +36,12 @@ class Meeting:
     def getDesc(self):
         return self.desc
 
+    def setMessage(self, message):
+        self.message = message
+
+    def getMessage(self):
+        return self.message
+
     def setAutoRemind(self, auto_remind):
         self.auto_remind = auto_remind
 
@@ -49,3 +56,9 @@ class Meeting:
     
     def getParticipants(self):
         return self.participants
+
+    def __repr__(self):
+        participant_names = []
+        for name in self.participants:
+            participant_names.append(name.name)
+        return "The meeting {} will happen at {} on {}:\nDescription: {}\nParticipants: {}".format(self.name, self.time, self.date, self.desc, ", ".join(participant_names))


### PR DESCRIPTION
Provided functionality for the bot to create a message when a meeting is created, and for users to opt-in to the meeting by reacting with the thumbs up emoji.

- main.py: added on_reaction_add async function that will check for reactions and verify if it is for a specific meeting. The user is added to the participant list.
- schedule.py: added a message member which will keep track of the message that will allow reactions to enroll. Furthermore, added __repr__ function.

Note: known bug where having multiple meetings and reacting to either will automatically enroll users into all of them.